### PR TITLE
Upgrade from cvc4 to cvc5

### DIFF
--- a/spark_ada/mlkem.gpr
+++ b/spark_ada/mlkem.gpr
@@ -172,7 +172,7 @@ library project MLKEM is
                                       "--no-inlining",
                                       "--no-loop-unrolling",
                                       "--level=1",
-                                      "--prover=z3,cvc4,altergo",
+                                      "--prover=z3,cvc5,altergo",
                                       "--timeout=4",
                                       "--memlimit=0",
                                       "--steps=25000",

--- a/spark_ada/src/mlkem.adb
+++ b/spark_ada/src/mlkem.adb
@@ -1611,6 +1611,7 @@ is
          pragma Loop_Invariant (2**(I + 1) <= 128);
          pragma Loop_Invariant (I32 (K) = 2**(I + 1));
       end loop;
+      pragma Assert (I32 (K) = 128);
       pragma Assert (K = 128);
       return F_Hat; --  calls _memcpy()
    end NTT;


### PR DESCRIPTION
This makes reference to the issue https://github.com/awslabs/LibMLKEM/issues/1.

I made gnatprove use cvc5 and added one Assert to make it prove everything (with my computer, cvc5 failed to prove the assertion line 1614).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
